### PR TITLE
Fix PlantUML block termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ zilctl pack secret.txt secret.zil
 
 # Расшифровка:
 zilctl unpack secret.zil --output-dir ./out
+```

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -21,3 +21,4 @@ CICD --> Vault : fetches secrets & rotates tokens
 Vault --> Core : provides AppRole tokens
 Vault --> Logger : optional key storage via env
 @enduml
+```


### PR DESCRIPTION
## Summary
- close the PlantUML code block in `docs/ARCH.md`
- close the Quickstart code block in `README.md`

## Testing
- `black --check docs/ARCH.md` *(fails: cannot parse for target version)*
- `black --check README.md` *(fails: cannot parse for target version)*
- `pytest -q` *(fails: unrecognized arguments due to missing pytest-cov)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683faaf99b14832fa530fc4bf43b5e1c