### PR TITLE
Enhance SecureLogger with TPM key fallback

### DIFF
--- a/tests/test_secure_logger_tpm.py
+++ b/tests/test_secure_logger_tpm.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+
+import os
+import subprocess
+import shutil
+
+from zilant_prime_core.utils.secure_logging import SecureLogger
+
+
+def test_secure_logger_fetches_tpm_key(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_which(cmd):
+        return "/usr/bin/tpm2_getrandom" if cmd == "tpm2_getrandom" else None
+
+    def fake_check_output(args, timeout=5):
+        calls["args"] = args
+        return b"x" * 32
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+    monkeypatch.delenv("ZILANT_LOG_KEY", raising=False)
+
+    slog = SecureLogger(log_path=str(tmp_path / "tpm.log"))
+    assert calls["args"] == ["tpm2_getrandom", "32"]
+    slog.log("hi")
+    assert slog.read_logs() == [("INFO", "hi")]

--- a/tests/test_secure_logger_tpm_failure.py
+++ b/tests/test_secure_logger_tpm_failure.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+
+import shutil
+import subprocess
+import pytest
+
+from zilant_prime_core.utils.secure_logging import SecureLogger
+
+
+def test_secure_logger_tpm_error(monkeypatch, tmp_path):
+    def fake_which(cmd):
+        return "/usr/bin/tpm2_getrandom" if cmd == "tpm2_getrandom" else None
+
+    def fake_check_output(args, timeout=5):
+        raise RuntimeError("tpm error")
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+    monkeypatch.delenv("ZILANT_LOG_KEY", raising=False)
+
+    with pytest.raises(ValueError):
+        SecureLogger(log_path=str(tmp_path / "tpm.log"))


### PR DESCRIPTION
## Summary
- fallback to TPM-generated key when no `ZILANT_LOG_KEY` set
- cover TPM key logic with tests

## Testing
- `ruff check tests/test_secure_logger_tpm.py tests/test_secure_logger_tpm_failure.py`
- `black tests/test_secure_logger_tpm.py tests/test_secure_logger_tpm_failure.py`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc07df024832fa60837f2e7dc4be0