### PR TITLE
fix: format file_monitor.py

### DIFF
--- a/src/zilant_prime_core/utils/file_monitor.py
+++ b/src/zilant_prime_core/utils/file_monitor.py
@@ -1,4 +1,5 @@
 """Watch critical files and exit if modified."""
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary
- run black on file_monitor.py so black check passes

## Testing
- `black --check src/zilant_prime_core/utils/file_monitor.py`
- `pytest -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3376028832f9da3d544cf7cda16