### PR TITLE
Disable vault steps in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,13 +115,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch secrets from Vault
-        uses: hashicorp/vault-action@v2
-        with:
-          url: ${{ secrets.VAULT_URL }}
-          method: github
-          path: secret/data/zilant
-          token: ${{ secrets.VAULT_TOKEN }}
+      #- name: Fetch secrets from Vault
+      #  uses: hashicorp/vault-action@v2
+      #  with:
+      #    url: ${{ secrets.VAULT_URL }}
+      #    method: github
+      #    path: secret/data/zilant
+      #    token: ${{ secrets.VAULT_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/vault-secrets.yml
+++ b/.github/workflows/vault-secrets.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@v3
 
       # ──────── 1) HashiCorp Vault ────────
-      - name: Login to HashiCorp Vault
-        uses: hashicorp/vault-action@v2
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: token
-          token: ${{ secrets.VAULT_TOKEN }}
+        #- name: Login to HashiCorp Vault
+        #  uses: hashicorp/vault-action@v2
+        #  with:
+        #    url: ${{ secrets.VAULT_ADDR }}
+        #    method: token
+        #    token: ${{ secrets.VAULT_TOKEN }}
 
       - name: Read ZILANT_LOG_KEY from Vault
         id: get-log-key


### PR DESCRIPTION
## Summary
- temporarily comment out HashiCorp Vault steps in CI
- temporarily comment out HashiCorp Vault steps in vault-secrets workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/vault-secrets.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe5c8f42c832fbf1ee3cf481b9d76