### PR TITLE
Fix CLI monitor issue

### DIFF
--- a/tests/test_file_monitor.py
+++ b/tests/test_file_monitor.py
@@ -24,3 +24,19 @@ def test_monitor_detects_change(tmp_path):
     finally:
         observer.stop()
         observer.join()
+
+
+def test_start_file_monitor_fallback(monkeypatch):
+    """start_file_monitor returns dummy observer if Observer.start fails."""
+
+    class BrokenObserver:
+        def schedule(self, handler, path, recursive=False):
+            pass
+
+        def start(self):
+            raise TypeError("bad handle")
+
+    monkeypatch.setattr("zilant_prime_core.utils.file_monitor.Observer", BrokenObserver)
+
+    obs = start_file_monitor(["dummy.txt"])
+    assert hasattr(obs, "stop") and hasattr(obs, "join")


### PR DESCRIPTION
## Summary
- handle monitor startup errors gracefully
- add tests for CLI when monitor fails
- add unit test for file_monitor fallback

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401b7c6a58832f8e3e8c553139f7fd