### PR TITLE
Fix CLI pack error message

### DIFF
--- a/src/zilant_prime_core/cli.py
+++ b/src/zilant_prime_core/cli.py
@@ -127,7 +127,7 @@ def cmd_pack(source: Path, output: Path | None, password: str | None, overwrite:
             _abort(f"{dest.name} already exists")
         overwrite = True
 
-    if password is None:
+    if not password:
         _abort("Missing password")
     if password == "-":
         password = _ask_pwd(confirm=True)

--- a/src/zilant_prime_core/cli.py
+++ b/src/zilant_prime_core/cli.py
@@ -128,6 +128,7 @@ def cmd_pack(source: Path, output: Path | None, password: str | None, overwrite:
         overwrite = True
 
     if not password:
+        # No password provided via the -p option or empty value
         _abort("Missing password")
     if password == "-":
         password = _ask_pwd(confirm=True)


### PR DESCRIPTION
## Summary
- handle empty password argument in CLI pack command

## Testing
- `pytest --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_6840a589955c832f808fe867ef055b27