### PR TITLE
Fix pack CLI password check order

### DIFF
--- a/src/zilant_prime_core/cli.py
+++ b/src/zilant_prime_core/cli.py
@@ -182,12 +182,12 @@ def cmd_unpack(container: Path, dest: Path | None, password: str | None) -> None
     if password == "-":
         password = _ask_pwd()
 
-    _init_runtime()
-
     out_dir = dest if dest is not None else container.parent
 
     if dest is not None and out_dir.exists():
         _abort("Destination path already exists")
+
+    _init_runtime()
 
     if dest is None:
         _cleanup_old_file(container)

--- a/src/zilant_prime_core/cli.py
+++ b/src/zilant_prime_core/cli.py
@@ -76,13 +76,9 @@ def _maybe_sandbox() -> None:
         os.execvp(cmd[0], cmd)
 
 
-@click.group(context_settings={"help_option_names": ["-h", "--help"]})
-def cli() -> None:
-    """Zilant Prime CLI."""
-    runsc_path = shutil.which("runsc")
-    if runsc_path is not None and os.getenv("ZILANT_NO_SANDBOX") is None:
-        cmd = ["runsc", "run", "--"] + sys.argv
-        os.execvp(cmd[0], cmd)
+def _init_runtime() -> None:
+    """Run runtime checks like sandbox and TPM counter."""
+    _maybe_sandbox()
     attest_via_tpm()  # pragma: no cover
     try:
         counter = read_tpm_counter()
@@ -94,11 +90,20 @@ def cli() -> None:
     if prev_file.exists():
         prev = int(prev_file.read_text())
         if counter <= prev:
-            click.echo("TPM counter did not increase (possible rollback)! Exiting.", err=True)
+            click.echo(
+                "TPM counter did not increase (possible rollback)! Exiting.",
+                err=True,
+            )
             sys.exit(1)
     prev_file.write_text(str(counter))
     init_self_watchdog(module_file=os.path.realpath(__file__), interval=60.0)  # pragma: no cover
     start_file_monitor(["sbom.json", "sealed_aes_key.bin", "config.yaml"])  # pragma: no cover
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def cli() -> None:
+    """Zilant Prime CLI."""
+    pass
 
 
 @cli.command("pack")
@@ -132,6 +137,8 @@ def cmd_pack(source: Path, output: Path | None, password: str | None, overwrite:
         _abort("Missing password")
     if password == "-":
         password = _ask_pwd(confirm=True)
+
+    _init_runtime()
 
     if not _pack_rate_limiter.allow():
         log_suspicious_event("rate_limit_exceeded", {"command": "pack"})
@@ -174,6 +181,8 @@ def cmd_unpack(container: Path, dest: Path | None, password: str | None) -> None
         _abort("Missing password")
     if password == "-":
         password = _ask_pwd()
+
+    _init_runtime()
 
     out_dir = dest if dest is not None else container.parent
 

--- a/src/zilant_prime_core/utils/self_watchdog.py
+++ b/src/zilant_prime_core/utils/self_watchdog.py
@@ -46,7 +46,7 @@ def cross_watchdog(interval: float = 1.0) -> None:
     while True:
         try:
             os.kill(parent_pid, 0)
-        except OSError:
+        except OSError:  # pragma: no cover - parent process gone
             sys.exit(1)
         time.sleep(interval)
 

--- a/src/zilant_prime_core/utils/tpm_counter.py
+++ b/src/zilant_prime_core/utils/tpm_counter.py
@@ -31,9 +31,18 @@ def read_tpm_counter() -> int:
 
 def increment_tpm_counter() -> None:
     """Increment TPM counter via tpm2_increment."""
-    if subprocess.call(["which", "tpm2_increment"], stdout=subprocess.DEVNULL) != 0:
+    if (
+        subprocess.call(
+            [
+                "which",
+                "tpm2_increment",
+            ],
+            stdout=subprocess.DEVNULL,
+        )
+        != 0
+    ):  # pragma: no cover - system check
         raise TpmCounterError("TPM increment utility not found")
-    try:
-        subprocess.run(["tpm2_increment", "0x81010001"], check=True)
+    try:  # pragma: no cover - system call
+        subprocess.run(["tpm2_increment", "0x81010001"], check=True)  # pragma: no cover - system call
     except Exception as e:  # pragma: no cover - system call
         raise TpmCounterError(f"Cannot increment TPM counter: {e}")


### PR DESCRIPTION
## Summary
- ensure sandbox/TPM checks run only after a password is provided
- move environment initialization from CLI group to a new helper
- invoke runtime checks in `pack` and `unpack` once the password is validated

## Testing
- `isort src tests`
- `black src tests --check`
- `ruff check src tests`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410cf52208832fa4c7faa94143b996