### PR TITLE
Add Vault integration to pack CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,10 @@ pip install zilant-prime-core
 # Шифрование файла:
 zilctl pack secret.txt secret.zil
 
+# Или через HashiCorp Vault (поле `password`):
+export VAULT_ADDR="https://vault.example.com"
+export VAULT_TOKEN="s.1a2b3c4d"
+zilctl pack secret.txt --vault-path secret/data/zilant/password
+
 # Расшифровка:
 zilctl unpack secret.zil --output-dir ./out

--- a/tests/test_cli_vault.py
+++ b/tests/test_cli_vault.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+
+import pytest
+from click.testing import CliRunner
+
+import zilant_prime_core.cli as cli_mod
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_pack_vault_success(tmp_path, monkeypatch, runner):
+    src = tmp_path / "file.txt"
+    src.write_text("x")
+    dest = src.with_suffix(".zil")
+
+    class Dummy:
+        def get_secret(self, path, key):
+            assert path == "secret/data/test"
+            assert key == "password"
+            return "pw"
+
+    monkeypatch.setattr(cli_mod, "VaultClient", lambda: Dummy())
+    monkeypatch.setattr(
+        cli_mod,
+        "_ask_pwd",
+        lambda *a, **k: (_ for _ in ()).throw(Exception("should not prompt")),
+    )
+    res = runner.invoke(cli_mod.cli, ["pack", str(src), "--vault-path", "secret/data/test"])
+    assert res.exit_code == 0
+    assert dest.exists()
+
+
+def test_pack_vault_error_fallback(tmp_path, monkeypatch, runner):
+    src = tmp_path / "file.txt"
+    src.write_text("x")
+    dest = src.with_suffix(".zil")
+
+    class Dummy:
+        def get_secret(self, path, key):
+            raise KeyError("fail")
+
+    monkeypatch.setattr(cli_mod, "VaultClient", lambda: Dummy())
+    monkeypatch.setattr(cli_mod, "_ask_pwd", lambda *a, **k: "pw")
+    res = runner.invoke(cli_mod.cli, ["pack", str(src), "--vault-path", "secret/data/foo"])
+    assert "Vault error" in res.output
+    assert res.exit_code == 0
+    assert dest.exists()
+
+
+def test_pack_vault_ignored_when_password_flag(tmp_path, monkeypatch, runner):
+    src = tmp_path / "file.txt"
+    src.write_text("x")
+    dest = src.with_suffix(".zil")
+
+    def fail():
+        raise AssertionError("VaultClient should not be instantiated")
+
+    monkeypatch.setattr(cli_mod, "VaultClient", lambda: fail())
+    res = runner.invoke(
+        cli_mod.cli,
+        ["pack", str(src), "-p", "cmd", "--vault-path", "secret/data/foo"],
+    )
+    assert res.exit_code == 0
+    assert dest.exists()
+
+
+def test_pack_missing_both(tmp_path, runner):
+    src = tmp_path / "file.txt"
+    src.write_text("x")
+    res = runner.invoke(cli_mod.cli, ["pack", str(src)])
+    assert res.exit_code == 1
+    assert "Missing password" in res.output


### PR DESCRIPTION
## Summary
- allow fetching pack password from HashiCorp Vault with `--vault-path`
- document the new option in README
- test CLI Vault logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ce43641c832fae3c2163e278c79f