### PR TITLE
Implement metrics HTTP server and OTEL tracing

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -60,8 +60,6 @@ jobs:
     needs: quality
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    labels:
-      needs-large-runner: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -78,6 +76,16 @@ jobs:
         with: { python-version: "3.13" }
       - run: pip install -e .[dev]
       - run: pytest -q tests/test_cli_observability.py
+
+  observability:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.13" }
+      - run: pip install .[dev]
+      - run: pytest -q tests/test_metrics_server.py tests/test_tracing_cli.py
 
 # ──────────────────────────── Build + artefacts ─────────────────────
   build-pq:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ zilctl pack secret.txt --vault-path secret/data/zilant/password
 # Расшифровка:
 zilctl unpack secret.zil --output-dir ./out
 
+## Observability
+
+```bash
+zilant metrics serve --port 9200 &
+curl http://localhost:9200/metrics | grep zilant_command_duration_seconds
+```
+
+Set `ZILANT_TRACE=1` to print OpenTelemetry spans to the console.
+
 ### Shamir Secret Sharing
 
 Разделите мастер‑ключ на части и восстановите его при необходимости:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,3 +19,4 @@ documentation for details.
    api/autogen
    THREATS.rst
    architecture/index
+   observability

--- a/docs/observability.rst
+++ b/docs/observability.rst
@@ -1,0 +1,9 @@
+Observability
+=============
+
+Run the metrics server and fetch Prometheus data::
+
+   zilant metrics serve --port 9200 &
+   curl http://localhost:9200/metrics | grep zilant_command_duration_seconds
+
+Set ``ZILANT_TRACE=1`` to enable console tracing via OpenTelemetry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "zstandard>=0.23.0",
   "tqdm>=4.66.0",
   "psutil>=5.9.0",
+  "opentelemetry-sdk>=1.23,<2.0",
 ]
 
 [project.scripts]
@@ -80,6 +81,7 @@ dev = [
   "zstandard>=0.23.0",
   "tqdm>=4.66.0",
   "psutil>=5.9.0",
+  "opentelemetry-sdk>=1.23,<2.0",
 ]
 pq = [
   "pqclean[kyber768]",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,3 +40,4 @@ boto3>=1.28.0
 zstandard>=0.23.0
 tqdm>=4.66.0
 psutil>=5.9.0
+opentelemetry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ PyYAML>=6.0
 boto3>=1.28.0
 zstandard>=0.23.0
 tqdm>=4.66.0
+opentelemetry-sdk

--- a/src/zilant_prime_core/cli_commands.py
+++ b/src/zilant_prime_core/cli_commands.py
@@ -14,7 +14,7 @@ from typing import Final
 from key_lifecycle import recover_secret, shard_secret
 from zilant_prime_core.crypto.kdf import derive_key_dynamic
 from zilant_prime_core.crypto.password_hash import hash_password, verify_password
-from zilant_prime_core.metrics import metrics
+from zilant_prime_core.metrics import metrics, trace_cli
 
 __all__: Final = [
     "derive_key_cmd",
@@ -103,6 +103,7 @@ def shard_cmd() -> None:
 @click.option("--output-dir", type=click.Path(file_okay=False, path_type=Path), required=True)
 @click.pass_context
 @metrics.record_cli("shard_export")
+@trace_cli("shard.export")
 def shard_export_cmd(
     ctx: click.Context,
     master_key: Path | None,
@@ -136,6 +137,7 @@ def shard_export_cmd(
 @click.option("--output-file", type=click.Path(dir_okay=False, path_type=Path), required=True)
 @click.pass_context
 @metrics.record_cli("shard_import")
+@trace_cli("shard.import")
 def shard_import_cmd(ctx: click.Context, input_dir: Path, output_file: Path) -> None:
     """Recover secret from INPUT-DIR and write to OUTPUT-FILE."""
     meta_path = input_dir / "meta.json"
@@ -176,6 +178,7 @@ def stream_cmd() -> None:
 @click.option("--progress/--no-progress", default=False, show_default=True)
 @click.pass_context
 @metrics.record_cli("stream_pack")
+@trace_cli("stream.pack")
 def stream_pack_cmd(ctx: click.Context, src: Path, dst: Path, key: Path, threads: int, progress: bool) -> None:
     """Pack SRC into DST using streaming AEAD."""
     from streaming_aead import pack_stream
@@ -194,6 +197,7 @@ def stream_pack_cmd(ctx: click.Context, src: Path, dst: Path, key: Path, threads
 @click.option("--offset", type=int, default=0, show_default=True, help="Skip first OFFSET bytes of ciphertext")
 @click.pass_context
 @metrics.record_cli("stream_unpack")
+@trace_cli("stream.unpack")
 def stream_unpack_cmd(
     ctx: click.Context,
     src: Path,

--- a/tests/test_metrics_server.py
+++ b/tests/test_metrics_server.py
@@ -1,0 +1,19 @@
+import os
+import time
+import urllib.request
+
+os.environ.setdefault("ZILANT_TRACE", "1")
+
+from zilant_prime_core.metrics import metrics, start_metrics_server
+
+
+def test_metrics_server_autopick(capsys):
+    os.environ.setdefault("ZILANT_TRACE", "1")
+    port = start_metrics_server(0)
+    captured = capsys.readouterr()
+    if not port:
+        port = int(captured.out.strip() or captured.err.strip())
+    time.sleep(0.1)
+    metrics.files_processed_total.inc()
+    data = urllib.request.urlopen(f"http://localhost:{port}/metrics").read().decode()
+    assert "command_duration_seconds" in data

--- a/tests/test_tracing_cli.py
+++ b/tests/test_tracing_cli.py
@@ -1,0 +1,19 @@
+from click.testing import CliRunner
+
+
+def test_tracing_span(tmp_path, monkeypatch):
+    monkeypatch.setenv("ZILANT_TRACE", "1")
+    monkeypatch.setenv("ZILANT_ALLOW_ROOT", "1")
+    # metrics imported with tracing enabled via test_metrics_server
+    from zilant_prime_core.cli import cli
+
+    src = tmp_path / "f.txt"
+    src.write_text("x")
+    res = CliRunner().invoke(
+        cli,
+        ["pack", str(src), "-p", "pw", "--dry-run"],
+        env={"ZILANT_TRACE": "1", "ZILANT_ALLOW_ROOT": "1"},
+    )
+    assert res.exit_code == 0
+    assert "[Span]" in res.output
+    assert "cli.command=pack" in res.output


### PR DESCRIPTION
## Summary
- expose prometheus metrics via `start_metrics_server`
- add `metrics serve` CLI command
- integrate OpenTelemetry tracing with `trace_cli`
- document metrics usage and tracing
- add observability tests and CI job
- fix workflow syntax issue

## Testing
- `pre-commit run --files src/zilant_prime_core/metrics.py src/zilant_prime_core/cli.py src/zilant_prime_core/cli_commands.py tests/test_metrics_server.py tests/test_tracing_cli.py README.md docs/index.rst docs/observability.rst .github/workflows/quality.yml`
- `pytest -q tests/test_metrics_server.py tests/test_tracing_cli.py`
- `make -C docs html` *(fails: WARNING: html_static_path entry '_static' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6854df03ca58832fa12581e6729e0c1f