### PR TITLE
Add quantum anonymity experimental modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ zilctl login --server https://auth.example --username alice
 
 Source and tests are maintained by @QuantumKeyUYU, while documentation also lists @DocMaintainers. CI workflows fall under @DevSecOpsTeam. Pull requests run Semgrep with custom rules in `.semgrep.yml` to prevent hardcoded keys and insecure random usage.
 
+## Quantum Anonymity & Security
+
+Experimental modules showcasing quantum resistant techniques can be found in
+`docs/ANONYMITY.md` and `docs/QUANTUM_SECURITY.md`.
+
 ## TODO Stage III
 
 - GUI demonstration (PyQt/Web)

--- a/docs/ANONYMITY.md
+++ b/docs/ANONYMITY.md
@@ -1,0 +1,5 @@
+# Quantum Anonymity Layer
+
+The modules `qal` and `qssa` provide simple helpers for experimenting with
+post-quantum anonymity techniques. They are intentionally lightweight and do
+not implement production ready ring signatures or stealth address schemes.

--- a/docs/QUANTUM_SECURITY.md
+++ b/docs/QUANTUM_SECURITY.md
@@ -1,0 +1,5 @@
+# Quantum Security Modules
+
+`zkqp`, `qvpn`, `qema` and `quantum_ra` are minimal stubs demonstrating how
+quantum-resistant primitives could be wired into the project. They are mainly
+for documentation and testing purposes.

--- a/src/zilant_prime_core/utils/__init__.py
+++ b/src/zilant_prime_core/utils/__init__.py
@@ -38,6 +38,12 @@ from .shard_secret import recover_secret, split_secret
 
 # ───────────────────────── Vault integration ────────────────────────
 from .vault_client import VaultClient
+from .qal import QAL
+from .qssa import QSSA
+from .zkqp import ZKQP
+from .qvpn import QVPN
+from .qema import QEMA
+from .quantum_ra import QuantumRA
 
 __all__: list[str] = [
     # constants.py
@@ -81,4 +87,10 @@ __all__: list[str] = [
     "HoneyfileError",
     "check_tmp_for_honeyfiles",
     "generate_daily_challenge",
+    "QAL",
+    "QSSA",
+    "ZKQP",
+    "QVPN",
+    "QEMA",
+    "QuantumRA",
 ]

--- a/src/zilant_prime_core/utils/qal.py
+++ b/src/zilant_prime_core/utils/qal.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+"""Simplified Quantum Anonymity Layer (QAL).
+
+This module provides a very small abstraction over ``PQSign`` to mimic
+ring signature behaviour. It should **not** be considered a real
+implementation of post-quantum ring signatures but merely a helper for
+experimentation and tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+from .pq_sign import PQSign
+
+
+class QAL:
+    """Manage a group of post-quantum signers."""
+
+    def __init__(self, group_size: int, work_dir: Path) -> None:
+        self.signers: List[PQSign] = []
+        self.keys: List[Tuple[Path, Path]] = []
+        self.work_dir = work_dir
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(group_size):
+            signer = PQSign()
+            priv = work_dir / f"sk_{i}.bin"
+            pub = work_dir / f"pk_{i}.bin"
+            signer.keygen(priv, pub)
+            self.signers.append(signer)
+            self.keys.append((priv, pub))
+
+    def sign(self, message: bytes, index: int) -> bytes:
+        priv, _ = self.keys[index]
+        return self.signers[index].sign(message, priv)
+
+    def verify(self, message: bytes, signature: bytes) -> bool:
+        for signer, (_, pub) in zip(self.signers, self.keys):
+            if signer.verify(message, signature, pub):
+                return True
+        return False

--- a/src/zilant_prime_core/utils/qema.py
+++ b/src/zilant_prime_core/utils/qema.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+"""Quantum-Enhanced Metadata Anonymizer (QEMA) placeholder."""
+
+from __future__ import annotations
+
+
+class QEMA:
+    """Remove known metadata fields."""
+
+    def anonymize(self, data: dict) -> dict:
+        sensitive = {"timestamp", "source", "author"}
+        return {k: v for k, v in data.items() if k not in sensitive}

--- a/src/zilant_prime_core/utils/qssa.py
+++ b/src/zilant_prime_core/utils/qssa.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+"""Quantum-Safe Stealth Addresses (QSSA).
+
+Addresses are ephemeral public keys generated using ``HybridKEM``.
+This is a minimal helper and not a full stealth address scheme.
+"""
+
+from __future__ import annotations
+
+import os
+from .pq_crypto import HybridKEM
+
+
+class QSSA:
+    """Generate ephemeral address key pairs."""
+
+    def __init__(self) -> None:
+        try:
+            self.kem = HybridKEM()
+        except Exception:  # pragma: no cover - optional dependency
+            self.kem = None
+
+    def generate_address(self):
+        """Return a new `(public_key, private_key)` pair."""
+        if self.kem is not None:
+            pk_pq, sk_pq, pk_x, sk_x = self.kem.generate_keypair()
+            public = (pk_pq, pk_x)
+            private = (sk_pq, sk_x)
+            return public, private
+        pub = os.urandom(32)
+        priv = os.urandom(32)
+        return pub, priv

--- a/src/zilant_prime_core/utils/quantum_ra.py
+++ b/src/zilant_prime_core/utils/quantum_ra.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+"""Secure Remote Attestation placeholder using PQ signatures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .pq_sign import PQSign
+
+
+class QuantumRA:
+    """Attest and verify device information."""
+
+    def __init__(self, work_dir: Path) -> None:
+        self.signer = PQSign()
+        self.work_dir = work_dir
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        self.sk = work_dir / "ra_sk.bin"
+        self.pk = work_dir / "ra_pk.bin"
+        self.signer.keygen(self.sk, self.pk)
+
+    def attest(self, info: bytes) -> bytes:
+        return self.signer.sign(info, self.sk)
+
+    def verify(self, info: bytes, signature: bytes) -> bool:
+        return self.signer.verify(info, signature, self.pk)

--- a/src/zilant_prime_core/utils/qvpn.py
+++ b/src/zilant_prime_core/utils/qvpn.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+"""Quantum-Hardened VPN/TOR integration stub."""
+
+from __future__ import annotations
+
+
+class QVPN:
+    """Simple placeholder for VPN/TOR routing."""
+
+    def __init__(self) -> None:
+        self._enabled = False
+
+    def enable(self) -> None:
+        self._enabled = True
+
+    def disable(self) -> None:
+        self._enabled = False
+
+    def is_enabled(self) -> bool:
+        return self._enabled

--- a/src/zilant_prime_core/utils/zkqp.py
+++ b/src/zilant_prime_core/utils/zkqp.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+"""Zero-Knowledge Quantum-Proofs (ZKQP) placeholder."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from .pq_sign import PQSign
+
+
+class ZKQP:
+    """Very small commitment scheme using ``PQSign``."""
+
+    def __init__(self, work_dir: Path) -> None:
+        self.signer = PQSign()
+        self.work_dir = work_dir
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        self.sk = work_dir / "zkqp_sk.bin"
+        self.pk = work_dir / "zkqp_pk.bin"
+        self.signer.keygen(self.sk, self.pk)
+
+    def prove(self, data: bytes) -> tuple[bytes, bytes]:
+        commit = hashlib.sha256(data).digest()
+        proof = self.signer.sign(commit, self.sk)
+        return commit, proof
+
+    def verify(self, data: bytes, commit: bytes, proof: bytes) -> bool:
+        expected = hashlib.sha256(data).digest()
+        if commit != expected:
+            return False
+        return self.signer.verify(commit, proof, self.pk)

--- a/tests/test_qal.py
+++ b/tests/test_qal.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+
+from zilant_prime_core.utils.qal import QAL
+
+
+def test_qal_sign_verify(tmp_path):
+    group = QAL(3, tmp_path)
+    msg = b"quantum"
+    sig = group.sign(msg, 1)
+    assert group.verify(msg, sig) is True
+
+
+def test_qal_verify_fail(tmp_path):
+    group = QAL(2, tmp_path)
+    msg = b"hello"
+    sig = group.sign(msg, 0)
+    assert group.verify(b"other", sig) is False

--- a/tests/test_qema.py
+++ b/tests/test_qema.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+
+from zilant_prime_core.utils.qema import QEMA
+
+
+def test_qema_anonymize():
+    q = QEMA()
+    data = {"msg": "hi", "timestamp": "now", "author": "me"}
+    anon = q.anonymize(data)
+    assert "timestamp" not in anon and "author" not in anon
+    assert anon["msg"] == "hi"

--- a/tests/test_qssa.py
+++ b/tests/test_qssa.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+
+from zilant_prime_core.utils.qssa import QSSA
+
+
+def test_qssa_unique_addresses():
+    q = QSSA()
+    pub1, _ = q.generate_address()
+    pub2, _ = q.generate_address()
+    assert pub1 != pub2

--- a/tests/test_quantum_ra.py
+++ b/tests/test_quantum_ra.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+
+from zilant_prime_core.utils.quantum_ra import QuantumRA
+
+
+def test_quantum_ra(tmp_path):
+    ra = QuantumRA(tmp_path)
+    info = b"device"
+    sig = ra.attest(info)
+    assert ra.verify(info, sig) is True
+    assert ra.verify(b"other", sig) is False

--- a/tests/test_qvpn.py
+++ b/tests/test_qvpn.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+
+from zilant_prime_core.utils.qvpn import QVPN
+
+
+def test_qvpn_toggle():
+    q = QVPN()
+    assert q.is_enabled() is False
+    q.enable()
+    assert q.is_enabled() is True
+    q.disable()
+    assert q.is_enabled() is False

--- a/tests/test_zkqp.py
+++ b/tests/test_zkqp.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
+# SPDX-License-Identifier: MIT
+
+from zilant_prime_core.utils.zkqp import ZKQP
+
+
+def test_zkqp_prove_verify(tmp_path):
+    z = ZKQP(tmp_path)
+    data = b"secret"
+    commit, proof = z.prove(data)
+    assert z.verify(data, commit, proof) is True
+
+
+def test_zkqp_verify_fail(tmp_path):
+    z = ZKQP(tmp_path)
+    data = b"secret"
+    commit, proof = z.prove(data)
+    assert z.verify(b"other", commit, proof) is False


### PR DESCRIPTION
## Summary
- add experimental quantum-related utility modules
- include docs covering anonymity and quantum security
- update README with links to new docs
- provide tests for new modules

## Testing
- `pytest tests/test_qal.py tests/test_qssa.py tests/test_zkqp.py tests/test_qvpn.py tests/test_qema.py tests/test_quantum_ra.py`

------
https://chatgpt.com/codex/tasks/task_e_68556c810d54832faa3a352a346b65f0