### PR TITLE
Fix tests and imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ zstandard>=0.23.0
 tqdm>=4.66.0
 requests>=2.32.0
 hvac~=2.0
+filelock>=3.13.0
+tabulate>=0.9

--- a/src/container.py
+++ b/src/container.py
@@ -27,14 +27,17 @@ except ModuleNotFoundError:  # pragma: no cover - installed package path
             return hashlib.sha3_256(data).digest()
 
 
+# Avoid importing through the package to prevent circular imports during
+# local development when ``container`` is imported before the package
+# ``zilant_prime_core`` is fully initialized.
 try:
-    from zilant_prime_core.utils.file_utils import atomic_write
-except ModuleNotFoundError:  # pragma: no cover - local imports during dev
     from utils.file_utils import atomic_write
+except ModuleNotFoundError:  # pragma: no cover - installed package path
+    from zilant_prime_core.utils.file_utils import atomic_write
 try:
-    from zilant_prime_core.utils.logging import get_logger
-except ModuleNotFoundError:  # pragma: no cover - local imports during dev
     from utils.logging import get_logger
+except ModuleNotFoundError:  # pragma: no cover - installed package path
+    from zilant_prime_core.utils.logging import get_logger
 
 ZIL_MAGIC = b"ZILANT"
 ZIL_VERSION = 1


### PR DESCRIPTION
## Summary
- avoid circular imports in `container` module
- include `filelock` and `tabulate` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bcfa6fc54832fa479a1813b8fc59b