### PR TITLE
Fix mypy issues and adjust tests

### DIFF
--- a/src/container.py
+++ b/src/container.py
@@ -4,17 +4,18 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, DefaultDict, cast
 
 try:
-    from zilant_prime_core.crypto.aead import PQAEAD, decrypt, encrypt
+    from zilant_prime_core.crypto.aead import PQAEAD, decrypt, encrypt  # type: ignore[attr-defined]
 except Exception:
     try:
-        from zilant_prime_core.aead import PQAEAD, decrypt, encrypt
+        from zilant_prime_core.aead import PQAEAD, decrypt, encrypt  # type: ignore[attr-defined]
     except Exception:  # pragma: no cover - local imports during dev
-        from aead import PQAEAD, decrypt, encrypt
+        from aead import PQAEAD, decrypt, encrypt  # type: ignore[attr-defined]
 try:
     from crypto_core import hash_sha3
 except ModuleNotFoundError:  # pragma: no cover - installed package path
@@ -34,13 +35,13 @@ except ModuleNotFoundError:  # pragma: no cover - local imports during dev
 try:
     from zilant_prime_core.utils.logging import get_logger
 except ModuleNotFoundError:  # pragma: no cover - local imports during dev
-    from utils.logging import get_logger
+    from utils.logging import get_logger  # type: ignore[assignment]
 
 ZIL_MAGIC = b"ZILANT"
 ZIL_VERSION = 1
 HEADER_SEPARATOR = b"\n\n"
 
-logger = get_logger("container")
+logger = cast(logging.Logger, get_logger("container"))
 
 # in-memory counter of unpack attempts per container path
 _ATTEMPTS: DefaultDict[str, int] = defaultdict(int)
@@ -205,7 +206,7 @@ def pack(meta: dict[str, Any], payload: bytes, key: bytes) -> bytes:
         raise ValueError("key must be 32 bytes long")
 
     header_bytes: bytes = json.dumps(meta, ensure_ascii=False).encode("utf-8") + HEADER_SEPARATOR
-    nonce, ciphertext = encrypt(key, payload, aad=b"")
+    nonce, ciphertext = cast(tuple[bytes, bytes], encrypt(key, payload, aad=b""))
     return header_bytes + nonce + ciphertext
 
 
@@ -264,14 +265,14 @@ def verify_integrity(path: Path) -> bool:
 
 
 __all__ = [
-    "pack_file",
-    "unpack_file",
-    "pack",
-    "unpack",
-    "get_metadata",
-    "get_open_attempts",
-    "verify_integrity",
+    "HEADER_SEPARATOR",
     "ZIL_MAGIC",
     "ZIL_VERSION",
-    "HEADER_SEPARATOR",
+    "get_metadata",
+    "get_open_attempts",
+    "pack",
+    "pack_file",
+    "unpack",
+    "unpack_file",
+    "verify_integrity",
 ]

--- a/src/zilant_prime_core/cli.py
+++ b/src/zilant_prime_core/cli.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import time
-import yaml  # type: ignore
+import yaml  # type: ignore[import-untyped]
 from pathlib import Path
 from typing import Any, NoReturn, cast
 
@@ -665,7 +665,7 @@ def cmd_show_metadata(container: Path) -> None:
 @click.option("--recursive", is_flag=True, help="Scan directories recursively")
 @click.option("--report", type=click.Choice(["json", "table"]), default="table")
 def cmd_heal_scan(path: Path, auto: bool, recursive: bool, report: str) -> None:
-    from tabulate import tabulate  # type: ignore
+    from tabulate import tabulate  # type: ignore[import-untyped]
 
     try:
         from zilant_prime_core.container import get_metadata, verify_integrity

--- a/src/zilant_prime_core/container/__init__.py
+++ b/src/zilant_prime_core/container/__init__.py
@@ -4,14 +4,16 @@
 # src/zilant_prime_core/container/__init__.py
 
 try:
-    from container import HEADER_SEPARATOR, get_metadata
+    from container import HEADER_SEPARATOR  # type: ignore[attr-defined]
+    from container import get_metadata  # type: ignore[attr-defined]
+    from container import pack_file  # type: ignore[attr-defined,no-redef]
     from container import pack as _pack
-    from container import pack_file, unpack_file, verify_integrity
+    from container import unpack_file, verify_integrity  # type: ignore[attr-defined,no-redef]
 except ModuleNotFoundError:  # pragma: no cover - installed as package
     HEADER_SEPARATOR = b"\n\n"
     from .metadata import get_metadata  # type: ignore
-    from .pack import pack as _pack
-    from .pack import pack_file
+    from .pack import pack as _pack  # type: ignore[assignment]
+    from .pack import pack_file  # type: ignore[attr-defined,no-redef]
     from .unpack import unpack_file, verify_integrity  # type: ignore
 else:
     from container import unpack as _unused_unpack  # noqa: F401
@@ -19,15 +21,15 @@ else:
 from .metadata import MetadataError
 from .unpack import unpack
 
-pack = _pack
+pack = _pack  # type: ignore[assignment]
 
 __all__ = [
-    "MetadataError",
     "HEADER_SEPARATOR",
-    "pack",
-    "unpack",
-    "pack_file",
-    "unpack_file",
+    "MetadataError",
     "get_metadata",
+    "pack",
+    "pack_file",
+    "unpack",
+    "unpack_file",
     "verify_integrity",
 ]

--- a/src/zilant_prime_core/self_heal/heal.py
+++ b/src/zilant_prime_core/self_heal/heal.py
@@ -18,8 +18,7 @@ try:
     from zilant_prime_core.container import HEADER_SEPARATOR
     from zilant_prime_core.container import pack as container_pack  # type: ignore[attr-defined]
 except ModuleNotFoundError:  # pragma: no cover - dev
-    from container import HEADER_SEPARATOR
-    from container import pack as container_pack  # type: ignore[no-redef]
+    from container import HEADER_SEPARATOR, pack as container_pack  # type: ignore[no-redef]
 from zilant_prime_core.crypto_core import hash_sha3
 
 try:
@@ -85,7 +84,7 @@ def heal_container(path: Path, key: bytes, *, rng_seed: bytes) -> bool:
 
     # Создаем новый контейнер
     try:
-        new_blob = pack(meta, payload, new_key)
+        new_blob = container_pack(meta, payload, new_key)
     except Exception as exc:
         record_action("self_heal_pack_failed", {"file": str(path), "error": str(exc)})
         os.unlink(lock_path)

--- a/src/zilant_prime_core/utils/recovery.py
+++ b/src/zilant_prime_core/utils/recovery.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:  # pragma: no cover - dev
 try:
     from zilant_prime_core.utils.logging import get_logger
 except ModuleNotFoundError:  # pragma: no cover - dev
-    from utils.logging import get_logger
+    from utils.logging import get_logger  # type: ignore[assignment,no-redef]
 _get_logger = get_logger
 try:
     from zilant_prime_core.utils.secure_memory import wipe_bytes

--- a/src/zilant_prime_core/zilfs.py
+++ b/src/zilant_prime_core/zilfs.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Tuple, cast
 
 
 # ───────────────────────────── fusepy (опционально)
-class Operations:  # noqa: D101
+class Operations:
     """Заглушка, если fusepy не установлен — нужна только для типизации."""
 
 
@@ -52,7 +52,7 @@ except ModuleNotFoundError:  # pragma: no cover - dev
 try:
     from zilant_prime_core.utils.logging import get_logger
 except ModuleNotFoundError:  # pragma: no cover - dev
-    from utils.logging import get_logger
+    from utils.logging import get_logger  # type: ignore[assignment,no-redef]
 _get_logger = get_logger
 
 from logging import Logger
@@ -81,7 +81,7 @@ class _ZeroFile:
     def __init__(self, size: int) -> None:
         self._remain = size
 
-    def read(self, n: int = -1) -> bytes:  # noqa: D401
+    def read(self, n: int = -1) -> bytes:
         if self._remain == 0:
             return b""
         if n < 0 or n > self._remain:
@@ -161,7 +161,7 @@ try:
             progress: int | None = None,
         ) -> int:  # pragma: no cover
             try:
-                return _ORIG_COPYFILE2(src, dst, flags, progress)  # type: ignore[arg-type]
+                return cast(int, _ORIG_COPYFILE2(src, dst, flags, progress))  # type: ignore[arg-type]
             except OSError as exc:
                 if getattr(exc, "winerror", None) != 112:
                     raise
@@ -205,7 +205,6 @@ def pack_dir_stream(src: Path, dest: Path, key: bytes) -> None:
     • Windows: «sparse-tar», большие файлы заменяем нулями.
     """
     with TemporaryDirectory() as tmp:
-
         fifo = os.path.join(tmp, "pipe_or_tar")
 
         # POSIX-ветка
@@ -240,6 +239,7 @@ def pack_dir_stream(src: Path, dest: Path, key: bytes) -> None:
 
         _mark_sparse(Path(fifo))
         pack_stream(Path(fifo), dest, key)
+
 
 def unpack_dir(container: Path, dest: Path, key: bytes) -> None:
     if not container.is_file():
@@ -370,7 +370,7 @@ class ZilantFS(Operations):  # type: ignore[misc]
         self._bytes_rw, self._start = 0, time.time()
         return mb / dur
 
-    def destroy(self, _p: str) -> None:  # noqa: D401
+    def destroy(self, _p: str) -> None:
         """Сериализовать tmp-каталог обратно в контейнер. Второй вызов — noop."""
         if not self.ro:
             try:

--- a/tests/test_decoy_gen_full.py
+++ b/tests/test_decoy_gen_full.py
@@ -61,7 +61,7 @@ def test_sweep_expired_decoys_handles_file_disappear(monkeypatch):
         dest_dir = Path(td)
         decoy_gen.generate_decoy_file(dest_dir / "boom.zil", expire_seconds=-1)
 
-        def fake_stat(self):
+        def fake_stat(self, *args, **kwargs):
             os.unlink(self)
             raise FileNotFoundError
 

--- a/tests/test_vdf_property.py
+++ b/tests/test_vdf_property.py
@@ -13,8 +13,11 @@ if sys.platform.startswith("win"):
         allow_module_level=True,
     )
 
-from hypothesis import given
-from hypothesis import strategies as st
+try:
+    from hypothesis import given
+    from hypothesis import strategies as st
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pytest.skip("hypothesis not installed", allow_module_level=True)
 
 import zilant_prime_core.vdf as vdf_mod
 
@@ -40,7 +43,6 @@ def test_posw_invalid_steps(seed, steps):
     steps=st.integers(min_value=1, max_value=100),
     bad_proof=st.binary(),
 )
-
 def test_posw_bad_proof_returns_false(seed, steps, bad_proof):
     # Генерируем правильное доказательство, но затем портим его на входе
     proof, ok = vdf_mod.posw(seed, steps)

--- a/tests/test_zilfs_missing_lines.py
+++ b/tests/test_zilfs_missing_lines.py
@@ -1,6 +1,10 @@
-import _winapi
 import importlib
 import pytest
+
+try:
+    import _winapi
+except ModuleNotFoundError:  # pragma: no cover - non-Windows
+    pytest.skip("_winapi module not available", allow_module_level=True)
 import sys
 from pathlib import Path
 

--- a/tests/test_zilfs_stream_big.py
+++ b/tests/test_zilfs_stream_big.py
@@ -1,5 +1,10 @@
-import _winapi
 import importlib
+import pytest
+
+try:
+    import _winapi
+except ModuleNotFoundError:  # pragma: no cover - non-Windows
+    pytest.skip("_winapi module not available", allow_module_level=True)
 import shutil
 from pathlib import Path
 

--- a/tests/test_zilfs_tree.py
+++ b/tests/test_zilfs_tree.py
@@ -1,5 +1,10 @@
-import _winapi
 import importlib
+import pytest
+
+try:
+    import _winapi
+except ModuleNotFoundError:  # pragma: no cover - non-Windows
+    pytest.skip("_winapi module not available", allow_module_level=True)
 import shutil
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- fix container import names for mypy
- adjust logging imports
- cast encrypt return for mypy
- skip Windows specific tests when modules are missing
- improve test helper

## Testing
- `pre-commit run --all-files`
- `ruff check src tests`
- `black --check src tests`
- `isort --check-only src tests`
- `mypy src`
- `pytest --cov=src --cov-report=term-missing` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685d38133394832f9157bd9313832ffd