### PR TITLE
Fix winapi imports in zilfs tests

### DIFF
--- a/tests/test_zilfs_missing_lines.py
+++ b/tests/test_zilfs_missing_lines.py
@@ -1,6 +1,6 @@
-import _winapi
-import importlib
 import pytest
+_winapi = pytest.importorskip("_winapi")
+import importlib
 import sys
 from pathlib import Path
 

--- a/tests/test_zilfs_stream_big.py
+++ b/tests/test_zilfs_stream_big.py
@@ -1,4 +1,5 @@
-import _winapi
+import pytest
+_winapi = pytest.importorskip("_winapi")
 import importlib
 import shutil
 from pathlib import Path

--- a/tests/test_zilfs_tree.py
+++ b/tests/test_zilfs_tree.py
@@ -1,4 +1,5 @@
-import _winapi
+import pytest
+_winapi = pytest.importorskip("_winapi")
 import importlib
 import shutil
 from pathlib import Path


### PR DESCRIPTION
## Summary
- skip Windows-specific zilfs tests when `_winapi` is not available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named '_winapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d480e24fc832f9ba9a17a6a4540e0