### PR TITLE
Apply formatting and cleanup

### DIFF
--- a/src/audit_ledger.py
+++ b/src/audit_ledger.py
@@ -12,8 +12,8 @@ __all__ = [
     "record_decoy_event",
     "record_decoy_purged",
     "record_decoy_removed_early",
-    "record_self_heal_triggered",
     "record_self_heal_done",
+    "record_self_heal_triggered",
 ]
 
 _LEDGER: Final[Path] = Path("audit-ledger.jsonl")

--- a/src/zilant_prime_core/tray.py
+++ b/src/zilant_prime_core/tray.py
@@ -11,6 +11,7 @@ src/zilant_prime_core/tray.py
 """
 
 from __future__ import annotations
+
 import os
 import sys
 from typing import TYPE_CHECKING, Any, Callable
@@ -21,7 +22,7 @@ ACTIVE_FS: list[Any] = []
 # ───────────────────────────── попытка импорта PySide6
 try:  # pragma: no cover
     # QtCore/QTimer — не используем при рендере, но тесты могут подменить
-    from PySide6.QtCore import QTimer  # noqa: F401
+    from PySide6.QtCore import QTimer
     from PySide6.QtGui import QIcon
     from PySide6.QtWidgets import QAction, QApplication, QMenu, QSystemTrayIcon
 except (ImportError, ModuleNotFoundError):
@@ -48,9 +49,9 @@ except (ImportError, ModuleNotFoundError):
 
 if TYPE_CHECKING:
     # Для mypy: эти имена существуют
-    from PySide6.QtCore import QTimer  # noqa: F811  # pragma: no cover
-    from PySide6.QtGui import QIcon  # noqa: F811   # pragma: no cover
-    from PySide6.QtWidgets import QAction, QApplication, QMenu, QSystemTrayIcon  # noqa: F811   # pragma: no cover
+    from PySide6.QtCore import QTimer  # pragma: no cover
+    from PySide6.QtGui import QIcon  # pragma: no cover
+    from PySide6.QtWidgets import QAction, QApplication, QMenu, QSystemTrayIcon  # pragma: no cover
 
 
 # ───────────────────────────── основная функция
@@ -110,12 +111,12 @@ def run_tray(icon_path: str | None = None) -> None:
 
 
 __all__ = [
-    "run_tray",
-    "QApplication",
-    "QSystemTrayIcon",
-    "QMenu",
-    "QAction",
-    "QIcon",
-    "QTimer",
     "ACTIVE_FS",
+    "QAction",
+    "QApplication",
+    "QIcon",
+    "QMenu",
+    "QSystemTrayIcon",
+    "QTimer",
+    "run_tray",
 ]

--- a/src/zilant_prime_core/utils/decoy.py
+++ b/src/zilant_prime_core/utils/decoy.py
@@ -12,18 +12,17 @@ import time
 from pathlib import Path
 from typing import Dict, List, Set
 
-
 from audit_ledger import record_decoy_purged, record_decoy_removed_early
 from container import get_metadata, pack_file
 
 __all__ = [
+    "clean_decoy_folder",
+    "delete_expired_decoy_files",
     "generate_decoy_file",
     "generate_decoy_files",
-    "is_decoy_file",
     "is_decoy_expired",
+    "is_decoy_file",
     "sweep_expired_decoys",
-    "delete_expired_decoy_files",
-    "clean_decoy_folder",
 ]
 
 _DECOY_EXPIRY: Dict[Path, float] = {}

--- a/src/zilant_prime_core/zilfs.py
+++ b/src/zilant_prime_core/zilfs.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Tuple, cast
 
 
 # ───────────────────────────── fusepy (опционально)
-class Operations:  # noqa: D101
+class Operations:
     """Заглушка, если fusepy не установлен — нужна только для типизации."""
 
 
@@ -81,7 +81,7 @@ class _ZeroFile:
     def __init__(self, size: int) -> None:
         self._remain = size
 
-    def read(self, n: int = -1) -> bytes:  # noqa: D401
+    def read(self, n: int = -1) -> bytes:
         if self._remain == 0:
             return b""
         if n < 0 or n > self._remain:
@@ -241,6 +241,7 @@ def pack_dir_stream(src: Path, dest: Path, key: bytes) -> None:
         _mark_sparse(Path(fifo))
         pack_stream(Path(fifo), dest, key)
 
+
 def unpack_dir(container: Path, dest: Path, key: bytes) -> None:
     if not container.is_file():
         raise FileNotFoundError(container)
@@ -370,7 +371,7 @@ class ZilantFS(Operations):  # type: ignore[misc]
         self._bytes_rw, self._start = 0, time.time()
         return mb / dur
 
-    def destroy(self, _p: str) -> None:  # noqa: D401
+    def destroy(self, _p: str) -> None:
         """Сериализовать tmp-каталог обратно в контейнер. Второй вызов — noop."""
         if not self.ro:
             try:

--- a/tests/test_vdf_property.py
+++ b/tests/test_vdf_property.py
@@ -40,7 +40,6 @@ def test_posw_invalid_steps(seed, steps):
     steps=st.integers(min_value=1, max_value=100),
     bad_proof=st.binary(),
 )
-
 def test_posw_bad_proof_returns_false(seed, steps, bad_proof):
     # Генерируем правильное доказательство, но затем портим его на входе
     proof, ok = vdf_mod.posw(seed, steps)


### PR DESCRIPTION
## Summary
- format zilfs and VDF property tests with black
- sort imports in tray and decoy helpers with isort
- clean up unused ``noqa`` directives with ruff and sort ``__all__``

## Testing
- `ruff check src/audit_ledger.py src/zilant_prime_core/tray.py src/zilant_prime_core/utils/decoy.py src/zilant_prime_core/zilfs.py tests/test_vdf_property.py`

------
https://chatgpt.com/codex/tasks/task_e_685d480da0f0832f80dcd1e4424675eb