### PR TITLE
Fix Dockerfile copy error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY pyproject.toml poetry.lock* /app/
+COPY pyproject.toml /app/
 RUN pip install --no-cache-dir poetry && \
     poetry config virtualenvs.create false && \
     poetry install --no-dev --no-interaction --no-ansi


### PR DESCRIPTION
## Summary
- avoid copying nonexistent `poetry.lock` when building the Docker image

## Testing
- `PYTHONPATH=src pytest -q tests/test_g_new.py::test_g_new_basic`

------
https://chatgpt.com/codex/tasks/task_e_6878ac199934832f86b270d9d21b42e9