### PR TITLE
fix: cast copyfile2 result to int

### DIFF
--- a/src/zilant_prime_core/zilfs.py
+++ b/src/zilant_prime_core/zilfs.py
@@ -149,7 +149,9 @@ try:
             progress: int | None = None,
         ) -> int:  # pragma: no cover
             try:
-                return _ORIG_COPYFILE2(src, dst, flags, progress)  # type: ignore[arg-type]
+                return int(
+                    _ORIG_COPYFILE2(src, dst, flags, progress)  # type: ignore[arg-type]
+                )
             except OSError as exc:
                 if getattr(exc, "winerror", None) != 112:
                     raise


### PR DESCRIPTION
## Summary
- cast result of Windows CopyFile2 wrapper to int to satisfy lint

## Testing
- `ruff check src/zilant_prime_core/zilfs.py`
- `pytest` *(fails: ModuleNotFoundError: No module named '_winapi')*


------
https://chatgpt.com/codex/tasks/task_e_688f9415c3a0832f890cd18febf7b2ed