### PR TITLE
fix: cast CopyFile2 return in zilfs

### DIFF
--- a/src/zilant_prime_core/zilfs.py
+++ b/src/zilant_prime_core/zilfs.py
@@ -149,7 +149,7 @@ try:
             progress: int | None = None,
         ) -> int:  # pragma: no cover
             try:
-                return _ORIG_COPYFILE2(src, dst, flags, progress)  # type: ignore[arg-type]
+                return cast(int, _ORIG_COPYFILE2(src, dst, flags, progress))  # type: ignore[arg-type]
             except OSError as exc:
                 if getattr(exc, "winerror", None) != 112:
                     raise


### PR DESCRIPTION
## Summary
- ensure patched CopyFile2 returns int for mypy

## Testing
- `pre-commit run --all-files`
- `ruff check src tests`
- `black --check src tests`
- `isort --check-only src tests`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_688f94b3d7b0832fa5502aa6e40441b5