### PR TITLE
fix vdf proof verification and streaming fallback

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,6 +29,7 @@ filelock>=3.13.0
 pynacl>=1.5.0
 pre-commit>=2.20.0
 atheris>=2.1.0; python_version < "3.12"
+tabulate>=0.9
 
 # Метрики и веб-сервер
 flask>=2.2.0

--- a/src/streaming_aead.py
+++ b/src/streaming_aead.py
@@ -38,9 +38,16 @@ def encrypt_chunk(key: bytes, nonce: bytes, data: bytes, aad: bytes = b"") -> by
     if _NativeAEAD is not None:
         ct = _NativeAEAD(key).encrypt(nonce, data, aad)
     else:
-        from nacl.bindings import crypto_aead_xchacha20poly1305_ietf_encrypt
+        try:
+            from nacl.bindings import crypto_aead_xchacha20poly1305_ietf_encrypt
+        except ImportError:  # pragma: no cover - если нет PyNaCl
+            from cryptography.hazmat.primitives.ciphers.aead import (
+                XChaCha20Poly1305,
+            )
 
-        ct = crypto_aead_xchacha20poly1305_ietf_encrypt(data, aad, nonce, key)
+            ct = XChaCha20Poly1305(key).encrypt(nonce, data, aad)
+        else:
+            ct = crypto_aead_xchacha20poly1305_ietf_encrypt(data, aad, nonce, key)
     return cast(bytes, ct)
 
 
@@ -52,9 +59,16 @@ def decrypt_chunk(key: bytes, nonce: bytes, cipher: bytes, aad: bytes = b"") -> 
     if _NativeAEAD is not None:
         pt = _NativeAEAD(key).decrypt(nonce, cipher, aad)
     else:
-        from nacl.bindings import crypto_aead_xchacha20poly1305_ietf_decrypt
+        try:
+            from nacl.bindings import crypto_aead_xchacha20poly1305_ietf_decrypt
+        except ImportError:  # pragma: no cover - если нет PyNaCl
+            from cryptography.hazmat.primitives.ciphers.aead import (
+                XChaCha20Poly1305,
+            )
 
-        pt = crypto_aead_xchacha20poly1305_ietf_decrypt(cipher, aad, nonce, key)
+            pt = XChaCha20Poly1305(key).decrypt(nonce, cipher, aad)
+        else:
+            pt = crypto_aead_xchacha20poly1305_ietf_decrypt(cipher, aad, nonce, key)
     return cast(bytes, pt)
 
 

--- a/src/zilant_prime_core/vdf/vdf.py
+++ b/src/zilant_prime_core/vdf/vdf.py
@@ -70,4 +70,9 @@ def check_posw(proof: bytes, data: bytes, steps: int = 1) -> bool:
     """
     Интерфейс для тестов: check_posw(proof, data, steps).
     """
-    return verify_posw_sha256(data, proof, steps)
+    # ensure the provided proof is *exactly* the one produced by ``posw``
+    # без каких-либо дополнительных байт
+    if not isinstance(proof, (bytes, bytearray)):
+        return False
+    expected, _ = posw(data, steps)
+    return bytes(proof) == expected and len(proof) == len(expected)

--- a/tests/test_vdf_property.py
+++ b/tests/test_vdf_property.py
@@ -38,7 +38,8 @@ def test_posw_invalid_steps(seed, steps):
 @given(
     seed=st.binary(min_size=1),
     steps=st.integers(min_value=1, max_value=100),
-    bad_proof=st.binary(),
+    # добавляем min_size=1, чтобы bad_proof никогда не был пустым
+    bad_proof=st.binary(min_size=1),
 )
 def test_posw_bad_proof_returns_false(seed, steps, bad_proof):
     # Генерируем правильное доказательство, но затем портим его на входе


### PR DESCRIPTION
## Summary
- add tabulate to dev requirements for self-heal CLI
- ensure check_posw validates proofs exactly and adjust property test
- improve streaming AEAD fallback to use cryptography when PyNaCl binding missing

## Testing
- `pytest tests/self_heal2/test_heal_success.py tests/test_vdf_property.py tests/test_streaming_aead_fallback.py tests/test_zilfs_stream_big.py tests/test_zstr_header.py`

------
https://chatgpt.com/codex/tasks/task_e_688ffc3e9600832faf7e2df2a49be854