### PR TITLE
chore: add tabulate runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "tqdm>=4.66.0",
   "psutil>=5.9.0",
   "requests>=2.32,<3.0",
+  "tabulate>=0.9",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add tabulate runtime dependency to project metadata

## Testing
- `pre-commit run --files pyproject.toml requirements.txt`
- `pytest tests/self_heal2/test_cli_scan_recursive.py::test_cli_scan_recursive tests/self_heal2/test_heal_success.py::test_heal_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68903e0abcf0832fa759260f743b3ed0