### PR TITLE
Ensure check_posw validates proof length and value

### DIFF
--- a/src/zilant_prime_core/vdf/vdf.py
+++ b/src/zilant_prime_core/vdf/vdf.py
@@ -70,4 +70,9 @@ def check_posw(proof: bytes, data: bytes, steps: int = 1) -> bool:
     """
     Интерфейс для тестов: check_posw(proof, data, steps).
     """
-    return verify_posw_sha256(data, proof, steps)
+    if not isinstance(proof, (bytes, bytearray)):
+        return False
+    expected = generate_posw_sha256(data, steps)
+    if len(proof) != len(expected):
+        return False
+    return proof == expected

--- a/tests/test_vdf_property.py
+++ b/tests/test_vdf_property.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Zilant Prime Core contributors
 # SPDX-License-Identifier: MIT
 
+import hashlib
 import pytest
 
 # tests/test_vdf_property.py
@@ -38,7 +39,7 @@ def test_posw_invalid_steps(seed, steps):
 @given(
     seed=st.binary(min_size=1),
     steps=st.integers(min_value=1, max_value=100),
-    bad_proof=st.binary(),
+    bad_proof=st.binary(min_size=1),
 )
 def test_posw_bad_proof_returns_false(seed, steps, bad_proof):
     # Генерируем правильное доказательство, но затем портим его на входе
@@ -47,3 +48,15 @@ def test_posw_bad_proof_returns_false(seed, steps, bad_proof):
     # сурово затираем
     bad = bad_proof + proof
     assert vdf_mod.check_posw(bad, seed, steps) is False
+
+
+@given(
+    seed=st.binary(min_size=1),
+    steps=st.integers(min_value=1, max_value=100),
+    prefix_len=st.integers(min_value=0, max_value=hashlib.sha256(b"\0").digest_size - 1),
+)
+def test_posw_prefix_returns_false(seed, steps, prefix_len):
+    proof, ok = vdf_mod.posw(seed, steps)
+    assert ok is True
+    prefix = proof[:prefix_len]
+    assert vdf_mod.check_posw(prefix, seed, steps) is False


### PR DESCRIPTION
## Summary
- Verify `check_posw` recomputes the expected digest and matches length and value exactly
- Strengthen VDF property tests to reject empty and non-empty prefixes

## Testing
- `pytest tests/test_vdf_property.py -q`
- `pytest -q` *(fails: FileNotFoundError: 'semgrep'; TypeError: unhashable type: 'types.SimpleNamespace')*

------
https://chatgpt.com/codex/tasks/task_e_68903e0bc3a8832f962304fc417e4d74