### PR TITLE
Set mypy to Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ line-length = 120
 max-complexity = 12
 
 [tool.mypy]
-python_version           = "3.13"
+python_version           = "3.11"
 strict                   = true
 allow_untyped_decorators = true
 warn_return_any          = false


### PR DESCRIPTION
## Summary
- target Python 3.11 for static type checking in mypy

## Testing
- `mypy src`
- `pre-commit run --files pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_6890458b9bf0832fb775ca7c86add8a2