### PR TITLE
fix: ensure CI installs lint and tabulate deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --no-cache-dir --no-binary :all: "pynacl>=1.5"
-          pip install .[test] "hypothesis>=6.104" "pytest-cov>=5.0" "coverage>=7.4"
+          pip install .[test] pre-commit "hypothesis>=6.104" "pytest-cov>=5.0" "coverage>=7.4"
 
       - name: Pre-commit
         run: pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "tqdm>=4.66.0",
   "psutil>=5.9.0",
   "requests>=2.32,<3.0",
+  "tabulate>=0.9",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,6 +29,7 @@ filelock>=3.13.0
 pynacl>=1.5.0
 pre-commit>=2.20.0
 atheris>=2.1.0; python_version < "3.12"
+tabulate>=0.9
 
 # Метрики и веб-сервер
 flask>=2.2.0


### PR DESCRIPTION
## Summary
- include tabulate in project and dev dependencies
- install pre-commit during CI run to execute hooks

## Testing
- `pre-commit run --files pyproject.toml requirements-dev.txt .github/workflows/ci.yml`
- `pytest tests/test_cli_commands.py::test_derive_key_cmd tests/test_cli_commands.py::test_pq_genkeypair_cmd -q`


------
https://chatgpt.com/codex/tasks/task_e_68906dd78888832f8687d7695c8eed08